### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lscpu.yml
+++ b/.github/workflows/lscpu.yml
@@ -1,4 +1,6 @@
 name: Get CPU Info
+permissions:
+  contents: read
 
 on: workflow_dispatch
 

--- a/.github/workflows/lscpu.yml
+++ b/.github/workflows/lscpu.yml
@@ -1,6 +1,6 @@
 name: Get CPU Info
 permissions:
-  contents: read
+  contents: write
 
 on: workflow_dispatch
 


### PR DESCRIPTION
Potential fix for [https://norascheuch.review-lab.github.com/security-campaigns-org/vulnerable-node/security/code-scanning/29](https://norascheuch.review-lab.github.com/security-campaigns-org/vulnerable-node/security/code-scanning/29)

To fix the issue, we should add a `permissions:` field to the workflow or directly to the job, specifying the least privileges required. Since this workflow only runs the `lscpu` command (a system command that does not interact with the GitHub API or repo contents), the optimal fix is to set `permissions: contents: read` either at the workflow root (top level) or under the job definition. Setting at the root applies to all jobs (there is only one here), and aligning with the recommendation, it should go as follows:

- Edit `.github/workflows/lscpu.yml`
- Add:

```yaml
permissions:
  contents: read
```

either at the top level, below the workflow `name`, and above/in proximity to the `on:` keyword.

No other methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
